### PR TITLE
Add Book properties

### DIFF
--- a/BookstoreApp/AddUpdateBook.cs
+++ b/BookstoreApp/AddUpdateBook.cs
@@ -10,6 +10,7 @@ namespace BookstoreApp
         private bool _isUpdate;
         private TextBox txtTitle;
         private TextBox txtPrice;
+        private TextBox txtISBN;
         private Button btnSave;
 
         public AddUpdateBook(Book? book = null)
@@ -25,17 +26,20 @@ namespace BookstoreApp
             this.Text = _isUpdate ? "Update Book" : "Add Book";
             txtTitle = new TextBox { Left = 20, Top = 20, Width = 200, Text = string.Empty, PlaceholderText = "Title" };
             txtPrice = new TextBox { Left = 20, Top = 60, Width = 200, Text = string.Empty, PlaceholderText = "Price" };
+            txtISBN = new TextBox { Left = 20, Top = 100, Width = 200, Text = string.Empty, PlaceholderText = "ISBN (13 digits)" };
 
             if (_book != null)
             {
                 txtTitle.Text = _book.Title;
                 txtPrice.Text = _book.Price.ToString();
+                txtISBN.Text = _book.ISBN;
             }
 
-            btnSave = new Button { Left = 20, Top = 100, Width = 200, Text = "Save" };
+            btnSave = new Button { Left = 20, Top = 140, Width = 200, Text = "Save" };
             btnSave.Click += BtnSave_Click;
             this.Controls.Add(txtTitle);
             this.Controls.Add(txtPrice);
+            this.Controls.Add(txtISBN);
             this.Controls.Add(btnSave);
         }
 
@@ -43,11 +47,24 @@ namespace BookstoreApp
         {
             if (_book is null)
             {
-                _book = new() { Title = txtTitle.Text };
+                string isbn = txtISBN.Text.Trim();
+                if (isbn.Length != 13 || !long.TryParse(isbn, out _))
+                {
+                    MessageBox.Show("ISBN must be exactly 13 digits (numbers only).");
+                    return;
+                }
+                _book = new Book { Title = txtTitle.Text, ISBN = isbn };
             }
             else
             {
                 _book.Title = txtTitle.Text;
+                string isbn = txtISBN.Text.Trim();
+                if (isbn.Length != 13 || !long.TryParse(isbn, out _))
+                {
+                    MessageBox.Show("ISBN must be exactly 13 digits (numbers only).");
+                    return;
+                }
+                _book.ISBN = isbn;
             } 
             if (double.TryParse(txtPrice.Text, out double price))
                 _book.Price = price;
@@ -66,7 +83,7 @@ namespace BookstoreApp
 
         private void InitializeComponent()
         {
-            this.ClientSize = new System.Drawing.Size(250, 150);
+            this.ClientSize = new System.Drawing.Size(250, 200);
             this.Text = "Book";
         }
     }

--- a/BookstoreApp/Book.cs
+++ b/BookstoreApp/Book.cs
@@ -29,6 +29,16 @@ namespace BookstoreApp
         public double Price { get; set; }
 
         /// <summary>
+        /// The 13 digit ISBN number. No dashes allowed, digits only
+        /// </summary>
+        public required string ISBN { get; set; }
+
+        /// <summary>
+        /// The optional user facing description of the book.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
         /// Displays book information
         /// </summary>
         /// <returns></returns>

--- a/BookstoreApp/Migrations/20250727225508_AddISBN.Designer.cs
+++ b/BookstoreApp/Migrations/20250727225508_AddISBN.Designer.cs
@@ -3,6 +3,7 @@ using BookstoreApp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookstoreApp.Migrations
 {
     [DbContext(typeof(BookStoreDb))]
-    partial class BookStoreDbModelSnapshot : ModelSnapshot
+    [Migration("20250727225508_AddISBN")]
+    partial class AddISBN
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -29,9 +32,6 @@ namespace BookstoreApp.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
-
                     b.Property<string>("ISBN")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
@@ -45,7 +45,7 @@ namespace BookstoreApp.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Books", (string)null);
+                    b.ToTable("Books");
                 });
 #pragma warning restore 612, 618
         }

--- a/BookstoreApp/Migrations/20250727225508_AddISBN.cs
+++ b/BookstoreApp/Migrations/20250727225508_AddISBN.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookstoreApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddISBN : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ISBN",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ISBN",
+                table: "Books");
+        }
+    }
+}

--- a/BookstoreApp/Migrations/20250727230041_BookDescription.Designer.cs
+++ b/BookstoreApp/Migrations/20250727230041_BookDescription.Designer.cs
@@ -3,6 +3,7 @@ using BookstoreApp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookstoreApp.Migrations
 {
     [DbContext(typeof(BookStoreDb))]
-    partial class BookStoreDbModelSnapshot : ModelSnapshot
+    [Migration("20250727230041_BookDescription")]
+    partial class BookDescription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -45,7 +48,7 @@ namespace BookstoreApp.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Books", (string)null);
+                    b.ToTable("Books");
                 });
 #pragma warning restore 612, 618
         }

--- a/BookstoreApp/Migrations/20250727230041_BookDescription.cs
+++ b/BookstoreApp/Migrations/20250727230041_BookDescription.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookstoreApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class BookDescription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Books");
+        }
+    }
+}


### PR DESCRIPTION
Closes #7 

This pull request introduces enhancements to the `BookstoreApp` project by adding support for ISBN and an optional book description. The changes include updates to the `Book` class, the `AddUpdateBook` form, and the database schema to accommodate these new fields. Below is a breakdown of the most important changes:

### Form Enhancements:
* Added a new `TextBox` (`txtISBN`) to the `AddUpdateBook` form for ISBN input, with validation to ensure it is exactly 13 digits and numeric. Updated layout to accommodate this new field. (`BookstoreApp/AddUpdateBook.cs`, [[1]](diffhunk://#diff-a83c82581783bb3479abe20dd650b74104c5b2438bc8689bc2f46e86bcb8de44R13) [[2]](diffhunk://#diff-a83c82581783bb3479abe20dd650b74104c5b2438bc8689bc2f46e86bcb8de44R29-R67) [[3]](diffhunk://#diff-a83c82581783bb3479abe20dd650b74104c5b2438bc8689bc2f46e86bcb8de44L69-R86)

### Model Updates:
* Updated the `Book` class to include a required `ISBN` property and an optional `Description` property. (`BookstoreApp/Book.cs`, [BookstoreApp/Book.csR31-R40](diffhunk://#diff-a4cc1373632870cfd2047a847d2a0289cf9cb4a20dddee439ba30a7f6bb15013R31-R40))

### Database Schema Updates:
* Added migrations to include the `ISBN` and `Description` fields in the `Books` table:
  - Migration `AddISBN`: Adds a required `ISBN` column. (`BookstoreApp/Migrations/20250727225508_AddISBN.cs`, [BookstoreApp/Migrations/20250727225508_AddISBN.csR1-R29](diffhunk://#diff-ff89e0b466e921ef3420a3eba4a1f2cd7984102dcfd0bd09a613b15c5314ce9bR1-R29))
  - Migration `BookDescription`: Adds an optional `Description` column. (`BookstoreApp/Migrations/20250727230041_BookDescription.cs`, [BookstoreApp/Migrations/20250727230041_BookDescription.csR1-R28](diffhunk://#diff-be1dd1bf9e3937d79473f5cc4c3bea541b961aa0ab7b3fc24f51c655a8790150R1-R28))
* Updated the `BookStoreDbModelSnapshot` to reflect the new schema changes. (`BookstoreApp/Migrations/BookStoreDbModelSnapshot.cs`, [[1]](diffhunk://#diff-b56ede138634954904db4143867e36e087c8d9f8a51a9ba2e917741a29994e58R32-R38) [[2]](diffhunk://#diff-b56ede138634954904db4143867e36e087c8d9f8a51a9ba2e917741a29994e58L41-R48)